### PR TITLE
Reduce the number of calls to the docker API when using project.up()

### DIFF
--- a/fig/container.py
+++ b/fig/container.py
@@ -54,6 +54,16 @@ class Container(object):
         response = client.create_container(**options)
         return cls.from_id(client, response['Id'])
 
+    @classmethod
+    def create_with_name(cls, client, name=None, **options):
+        response = client.create_container(name=name, **options)
+        dictionary = {
+            'Name': '/' + name,
+            'Image': options.get('image'),
+            'Id': response['Id'],
+        }
+        return cls(client, dictionary)
+
     @property
     def id(self):
         return self.dictionary['Id']

--- a/fig/project.py
+++ b/fig/project.py
@@ -230,11 +230,17 @@ class Project(object):
            recreate=True,
            insecure_registry=False,
            detach=False,
-           do_build=True):
+           do_build=True,
+           fresh_start=False):
         running_containers = []
         for service in self.get_services(service_names, include_links=start_links):
-            create_func = (service.recreate_containers if recreate
-                           else service.start_or_create_containers)
+
+            if fresh_start:
+                create_func = service.fresh_start
+            elif recreate:
+                create_func = service.recreate_containers
+            else:
+                create_func = service.start_or_create_containers
 
             for container in create_func(
                     insecure_registry=insecure_registry,

--- a/tests/integration/cli_test.py
+++ b/tests/integration/cli_test.py
@@ -399,17 +399,14 @@ class CLITestCase(DockerClientTestCase):
         service = self.project.get_service('simple')
         container = service.create_container()
         service.start_container(container)
-        started_at = container.dictionary['State']['StartedAt']
+        started_at = container.get('State.StartedAt')
         self.command.dispatch(['restart'], None)
         container.inspect()
         self.assertNotEqual(
-            container.dictionary['State']['FinishedAt'],
+            container.get('State.FinishedAt'),
             '0001-01-01T00:00:00Z',
         )
-        self.assertNotEqual(
-            container.dictionary['State']['StartedAt'],
-            started_at,
-        )
+        self.assertNotEqual(container.get('State.StartedAt'), started_at)
 
     def test_scale(self):
         project = self.project

--- a/tests/integration/service_test.py
+++ b/tests/integration/service_test.py
@@ -143,11 +143,12 @@ class ServiceTest(DockerClientTestCase):
             command=['300']
         )
         old_container = service.create_container()
-        self.assertEqual(old_container.dictionary['Config']['Entrypoint'], ['sleep'])
-        self.assertEqual(old_container.dictionary['Config']['Cmd'], ['300'])
-        self.assertIn('FOO=1', old_container.dictionary['Config']['Env'])
+        self.assertEqual(old_container.get('Config.Entrypoint'), ['sleep'])
+        self.assertEqual(old_container.get('Config.Cmd'), ['300'])
+        self.assertIn('FOO=1', old_container.get('Config.Env'))
         self.assertEqual(old_container.name, 'figtest_db_1')
         service.start_container(old_container)
+        old_container.inspect()
         volume_path = old_container.get('Volumes')['/etc']
 
         num_containers_before = len(self.client.containers(all=True))

--- a/tests/unit/container_test.py
+++ b/tests/unit/container_test.py
@@ -35,6 +35,19 @@ class ContainerTest(unittest.TestCase):
             "Name": "/figtest_db_1",
         })
 
+    def test_create_with_name(self):
+        mock_client = mock.create_autospec(docker.Client)
+        name = 'the_name'
+        options = {'image': 'busybox', 'ports': []}
+        container = Container.create_with_name(mock_client, name=name, **options)
+        mock_client.create_container.assert_called_once_with(
+            name=name, **options)
+        self.assertEqual(container.name, name)
+        self.assertEqual(container.name_without_project, 'name')
+        self.assertEqual(
+            container.id,
+            mock_client.create_container.return_value.__getitem__.return_value)
+
     def test_environment(self):
         container = Container(None, {
             'Id': 'abc',

--- a/tests/unit/project_test.py
+++ b/tests/unit/project_test.py
@@ -83,21 +83,17 @@ class ProjectTest(unittest.TestCase):
     def test_up_with_fresh_start(self):
         mock_client = mock.create_autospec(docker.Client)
         services = [
-            {'name': 'web', 'image': 'busybox:latest'},
+            {'name': 'web', 'image': 'busybox:latest', 'links': ['db']},
             {'name': 'db',  'image': 'busybox:latest'},
         ]
         project = Project.from_dicts('test', services, mock_client, None, None)
         containers = project.up(do_build=False, fresh_start=True)
         self.assertEqual(len(containers), 2)
-        expected = [
-            mock.call.create_container(
-                environment={},
-                image='busybox:latest',
-                detach=False,
-            ),
-            mock.call.start(
+
+        def build_start_call(links):
+            return mock.call.start(
                 mock_client.create_container.return_value.__getitem__.return_value,
-                links=[],
+                links=links,
                 cap_add=None,
                 restart_policy=None,
                 dns_search=None,
@@ -108,8 +104,28 @@ class ProjectTest(unittest.TestCase):
                 port_bindings={},
                 cap_drop=None,
                 privileged=False,
+            )
+
+        expected = [
+            mock.call.create_container(
+                environment={},
+                image='busybox:latest',
+                detach=False,
+                name='test_db_1',
             ),
-        ] * 2
+            build_start_call([]),
+            mock.call.create_container(
+                environment={},
+                image='busybox:latest',
+                detach=False,
+                name='test_web_1',
+            ),
+            build_start_call([
+                ('test_db_1', 'db'),
+                ('test_db_1', 'test_db_1'),
+                ('test_db_1', 'db_1'),
+            ]),
+        ]
         self.assertEqual(mock_client.method_calls, expected)
 
     def test_get_service_no_external(self):

--- a/tests/unit/service_test.py
+++ b/tests/unit/service_test.py
@@ -194,7 +194,7 @@ class ServiceTest(unittest.TestCase):
         mock_response = mock.Mock(Response)
         mock_response.status_code = 404
         mock_response.reason = "Not Found"
-        mock_container.create.side_effect = APIError(
+        mock_container.create_with_name.side_effect = APIError(
             'Mock error', mock_response, "No such image")
 
         # We expect the APIError because our service requires a
@@ -242,11 +242,15 @@ class ServiceTest(unittest.TestCase):
         self.assertEqual(parse_repository_tag("url:5000/repo"), ("url:5000/repo", ""))
         self.assertEqual(parse_repository_tag("url:5000/repo:tag"), ("url:5000/repo", "tag"))
 
-    def test_latest_is_used_when_tag_is_not_specified(self):
+    @mock.patch('fig.service.Container', autospec=True)
+    def test_latest_is_used_when_tag_is_not_specified(self, mock_container):
         service = Service('foo', client=self.mock_client, image='someimage')
-        Container.create = mock.Mock()
         service.create_container()
-        self.assertEqual(Container.create.call_args[1]['image'], 'someimage:latest')
+        mock_container.create_with_name.assert_called_once_with(
+            self.mock_client,
+            environment={},
+            image='someimage:latest',
+            name='default_foo_1')
 
 
 class ServiceVolumesTest(unittest.TestCase):

--- a/tests/unit/service_test.py
+++ b/tests/unit/service_test.py
@@ -242,6 +242,24 @@ class ServiceTest(unittest.TestCase):
         self.assertEqual(parse_repository_tag("url:5000/repo"), ("url:5000/repo", ""))
         self.assertEqual(parse_repository_tag("url:5000/repo:tag"), ("url:5000/repo", "tag"))
 
+    def test_get_links_with_service_only(self):
+        service_one = Service('one')
+        service_two = Service('two')
+        service = Service('foo', links=[
+            (service_one, None),
+            (service_two, 'other'),
+        ])
+
+        links = service._get_links(False, service_only_links=True)
+        self.assertEqual(links, [
+            ('default_one_1', 'one'),
+            ('default_one_1', 'default_one_1'),
+            ('default_one_1', 'one_1'),
+            ('default_two_1', 'other'),
+            ('default_two_1', 'default_two_1'),
+            ('default_two_1', 'two_1'),
+        ])
+
     @mock.patch('fig.service.Container', autospec=True)
     def test_latest_is_used_when_tag_is_not_specified(self, mock_container):
         service = Service('foo', client=self.mock_client, image='someimage')

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,6 @@
 envlist = py26,py27
 
 [testenv]
-usedevelop=True
 deps =
     -rrequirements.txt
     -rrequirements-dev.txt

--- a/wercker.yml
+++ b/wercker.yml
@@ -2,11 +2,5 @@ box: wercker-labs/docker
 build:
   steps:
     - script:
-        name: validate DCO
-        code: script/validate-dco
-    - script:
         name: run tests
         code: script/test
-    - script:
-        name: build binary
-        code: script/build-linux


### PR DESCRIPTION
- don't inspect the container immediately after creating it. Instead use the values passed to create for the name and Id
- add a new `fresh_start` kwarg to `project.up()` which doesn't try to restart containers, and assumes the containers it will be creating don't already exist. This allows us to skip the listing of containers entirely.
- with `fresh_start` assume that all containers will be named with a `_1` suffix so we also don't have to list containers to create links to them.

cc @osarood
